### PR TITLE
Enable cursor on iPhone 12

### DIFF
--- a/CURSOR_NO_IPHONE.md
+++ b/CURSOR_NO_IPHONE.md
@@ -1,0 +1,54 @@
+# Como Acessar o Cursor no iPhone 12
+
+## ⚠️ Informação Importante
+O Cursor é um editor de código desktop (disponível para Windows, macOS e Linux) e **não possui um aplicativo nativo para iPhone ou iOS**.
+
+## 📱 Alternativas para Usar o Cursor no iPhone 12
+
+### Opção 1: Acesso Remoto ao Computador
+Use seu iPhone para acessar remotamente um computador onde o Cursor está instalado:
+
+#### **Microsoft Remote Desktop** (Recomendado)
+1. Instale o Cursor no seu PC/Mac
+2. Baixe o app "Microsoft Remote Desktop" na App Store
+3. Configure o acesso remoto no seu computador
+4. Conecte-se do iPhone e use o Cursor remotamente
+
+#### **Chrome Remote Desktop**
+1. Configure o Chrome Remote Desktop no computador
+2. Acesse remotely.chromium.org no Safari do iPhone
+3. Controle seu computador e use o Cursor
+
+#### **TeamViewer**
+1. Instale o TeamViewer no computador e iPhone
+2. Conecte-se remotamente
+3. Use o Cursor através da conexão remota
+
+### Opção 2: Editores de Código para iOS
+Se você precisa editar código diretamente no iPhone, considere estas alternativas:
+
+- **Textastic** - Editor de código profissional para iOS
+- **Buffer Editor** - Editor de código simples e eficaz
+- **Koder** - Editor com suporte a múltiplas linguagens
+- **Working Copy** - Cliente Git com editor integrado
+
+### Opção 3: Soluções Cloud-Based
+Use ambientes de desenvolvimento na nuvem acessíveis pelo navegador do iPhone:
+
+- **GitHub Codespaces** - VS Code na nuvem
+- **Replit** - IDE online colaborativo
+- **CodeSandbox** - Para desenvolvimento web
+- **Gitpod** - Ambientes de desenvolvimento automatizados
+
+## 🔮 Futuro
+Atualmente não há planos oficiais anunciados para uma versão iOS do Cursor. A melhor experiência continua sendo no desktop.
+
+## 💡 Recomendação
+Para trabalho ocasional e emergencial no iPhone, use **acesso remoto** ao seu computador.
+Para edição leve de código, use **editores nativos iOS** como Textastic.
+Para projetos mais complexos, prefira usar o **Cursor no computador**.
+
+## 📝 Observações
+- O iPhone 12 tem tela de 6.1" - acesso remoto pode ser desafiador
+- Considere usar um iPad para melhor experiência
+- Teclado externo Bluetooth melhora muito a produtividade


### PR DESCRIPTION
Add `CURSOR_NO_IPHONE.md` to provide alternatives for using the Cursor editor on an iPhone 12, as there is no native iOS app.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa87c70f-9a37-461a-9b12-55a85f74ac4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa87c70f-9a37-461a-9b12-55a85f74ac4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

